### PR TITLE
[G2M] customizable login email timezone

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "bcryptjs": "^2.4.3",
     "jsonwebtoken": "^8.1.0",
     "lodash": "^4.17.5",
-    "luxon": "^0.5.8",
+    "moment-timezone": "^0.5.14",
     "mongodb": "^3.0.5",
     "nodemailer": "^4.4.0",
     "uuid": "^3.1.0"


### PR DESCRIPTION
allows `zone` query string parameter for more personalized login email expiry timestamp for `/login` endpoint invocation

fixes #6 