### PR TITLE
[G2M] Hardcoded Passcode for App Reviewer

### DIFF
--- a/modules/auth.js
+++ b/modules/auth.js
@@ -96,10 +96,10 @@ const loginUser = async ({ user, redirect, zone='utc', product='ATOM' }) => {
   sender = sender || 'dev@eqworks.com'
   company = company || 'EQ Works'
 
-  const userExists = await getUserInfo({ email: user })
-  const isAppReviewer = userExists.prefix === 'appreviewer'
+  const { prefix: userPrefix } = await getUserInfo({ email: user })
+  
   // generate and update user OTP, get TTL
-  const otp = (!isAppReviewer) ? _genOTP() : '000000'
+  const otp = (userPrefix !== 'appreviewer') ? _genOTP() : '*'.charCodeAt(0).toString(2)
   
   let ttl = await _updateOTP({ email: user, otp })
   // localize TTL


### PR DESCRIPTION
- small check to see user prefix and if it is appreviewer, instead of generating an OTP, make it 000000
- this will make it easy when providing test login credentials.
- tested with user (not in equsers table), a user with prefix that's not appreviewer, and user that does have prefix 'appreviewer'