### PR TITLE
jwt/long-lasting-jwt

### DIFF
--- a/api/root.js
+++ b/api/root.js
@@ -40,11 +40,12 @@ router.get('/login', hasQueryParams('user'), (req, res, next) => {
 
 // GET /verify
 router.get('/verify', hasQueryParams('user', 'otp'), (req, res, next) => {
-  const { user, reset_uuid, product } = req.query
+  const { user, reset_uuid, product, timeout } = req.query
   verifyOTP({
     ...req.query,
     reset_uuid: ['1', 'true'].includes(reset_uuid),
-    product
+    product,
+    timeout
   }).then(token => {
     return res.json({
       message: `User ${user} verified, please store and use the token responsibly`,


### PR DESCRIPTION
Add the option for high-privilege users to specify an expiry time for keywarden-issued JWTs.

A high-privilege user has:
- a user with an @eqworks.com email address
- full baseline access for all API functions (i.e. -1 for all attributes of the api_access object)
- ~running keywarden with the environment variable STAGE=dev~ when user object `prefix` is `dev`

To set an expiry date, set a timeout query parameter when calling the /verify endpoint, determining the expiry time in seconds. Setting timeout = 0 will return an instantly-expiring token. Setting timeout = -1 will return a token that never expires.