### PR TITLE
[G2M] devops - add commit-watch to master CI workflow

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -34,6 +34,7 @@ jobs:
 
   commit-watch:
     runs-on: ubuntu-latest
+    if: contains(github.event_name, 'pull_request')
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
- [`@eqworks/commit-watch`](https://github.com/EQWorks/commit-watch) integration
- official actions version update