### PR TITLE
[G2M] login - bypass SES in local env, Ethereal instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ jspm_packages
 
 # Serverless directories
 .serverless
+
+# IDE config
+.vscode


### PR DESCRIPTION
_[Slack thread](https://eqworks.slack.com/archives/GC79A1789/p1625507487000300)_
Related: 
- EQWorks/snoke#968
- EQWorks/overlord#1847
- EQWorks/common-login#15

To solve the problem of how to develop `keywarden` locally without access to AWS, this branch uses a random Ethereal sender and a random Ethereal recipient for OTP **when in its local stage.**

> [_Ethereal is a fake SMTP service, mostly aimed at Nodemailer users (but not limited to). It's a completely free anti-transactional email service where messages never get delivered._](https://ethereal.email/)

So, when `process.env.STAGE == 'local'` and a request is received for `/login?user=kyle.grimsrud-manz@eqworks.com`, `keywarden` does something like:

```
Local stage, sending email to test account instead of kyle.grimsrud-manz@eqworks.com...
...
{
    message: "View test email: https://ethereal.email/message/YOOCYi0yk1T9gqb7YOOCaSNBHHoRGiEJAAAAAj3HiIOQb-Wfyh8RoVoft6w"
    user: "h3nnkeh5k473oohp@ethereal.email"
} 
```

The "test email" URL leads to an inbox containing the magic link and/or token to authenticate successfully.