### PR TITLE
login - use correct var in nonlocal login response

### DIFF
--- a/api/root.js
+++ b/api/root.js
@@ -44,7 +44,7 @@ router.get('/login', hasQueryParams('user'), (req, res, next) => {
     }
     return res.json({
       message: `Login passcode sent to ${user} through email`,
-      user: deliveryInfo.accepted[0],
+      user,
     })
   }).catch(next)
 })


### PR DESCRIPTION
[Slack thread](https://eqworks.slack.com/archives/GBV4LU9HA/p1625840843005300)

Fixing #61 which was in turn a fix for #60. 