### PR TITLE
[G2M] Auth - add option to have prefixed users generate long-lasting JWTs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,13 @@ Upon receiving this, the requesting client should make `GET /verify` request on 
 
 ### Verify OTP
 
-`GET /verify?user=<REQUIRED: email>&otp=<REQUIRED: one-time passcode>&reset_uuid=[OPTIONAL: 1|true]&product=[OPTIONAL: atom|locus]`
+`GET /verify?user=<REQUIRED: email>&otp=<REQUIRED: one-time passcode>&reset_uuid=[OPTIONAL: 1|true]&product=[OPTIONAL: atom|locus]&timeout=[OPTIONAL: Number]`
 
 Upon receiving and validating the OTP obtained from the `/login` process, instead of having the requesting application to generate and maintain a "session", `keywarden` signs a stateless [JWT (JSON web token)](https://jwt.io) for the requesting product (default: 'atom') to use for further API access against `overseer` and alike.
 
 If `reset_uuid` is supplied as a value of `1` or `true`, given `user`'s `jwt_uuid` will be reset to a new value. This can be used to effectively invalidate all past tokens of given `user`.
+
+If 'timeout' is undefined, then the generated JWT token will be set to expire in \<JWT_TTL\> seconds (90 days if this env var is undefined). Otherwise, if 'timeout' is defined and the caller is a privileged user, then the token will expire in 'timeout' seconds. Finally, if 'timeout' is negative and the caller is a privileged user, then the JWT token will be set to never expire. A privileged user is a user with either a 'mobilesdk' prefix, or a 'dev' prefix with full api access permissions and an @eqworks.com email address.
 
 ### Confirm JWT 
 

--- a/modules/auth.js
+++ b/modules/auth.js
@@ -153,7 +153,9 @@ const isPrivilegedUser = (email, prefix, api_access) => {
   // returns true if this user is high-privilege
   // A user is high privilege if they have an eqworks email, a dev stage prefix,
   // and -1 access to all api_access fields
-  return Object.values(api_access).every(v => v === -1) && email.endsWith('@eqworks.com') && prefix == 'dev'
+  const isDev = Object.values(api_access).every(v => v === -1) && email.endsWith('@eqworks.com') && prefix == 'dev'
+  const isMobileSDK = prefix == 'mobilesdk'
+  return isDev || isMobileSDK
 }
 
 const verifyJWT = token => jwt.verify(token, JWT_SECRET)


### PR DESCRIPTION
- Users of prefix 'mobilesdk' can now generate long-lasting JWTs
- documentation on the GET /verify endpoint updated to include information on how to generate variable-expiry tokens