### PR TITLE
[G2M] api - augment confirm endpoint w/ expiration info

### DIFF
--- a/api/middleware.js
+++ b/api/middleware.js
@@ -1,6 +1,7 @@
 const { verifyJWT, confirmUser } = require('../modules/auth')
 const { PRODUCT_ATOM } = require('../constants')
 const { sentry, AuthorizationError, APIError } = require('../modules/errors')
+const moment = require('moment-timezone')
 
 
 // JWT confirmation middleware
@@ -38,6 +39,16 @@ const confirmed = ({ allowLight = false } = {}) => (req, res, next) => {
     req.userInfo = { ...user, light: true }
     return next()
   }
+
+  // determine JWT TTL
+  const ttl = 'exp' in user
+    ? 1000 * user.exp - Date.now()
+    : -1
+  req.ttl = {
+    millis: ttl,
+    friendly: moment.duration(ttl).humanize()
+  }
+
   confirmUser({
     ...user,
     reset_uuid: ['1', 'true'].includes(reset_uuid),

--- a/api/root.js
+++ b/api/root.js
@@ -71,8 +71,14 @@ router.get('/verify', hasQueryParams('user', 'otp'), (req, res, next) => {
 
 // GET /confirm
 router.get('/confirm', confirmed({ allowLight: true }), (req, res) => {
-  const { email: user, light } = req.userInfo
-  return res.json({ message: `Token confirmed for user ${user}`, user, light })
+  const { query: { product }, ttl, userInfo: { email: user, light } } = req
+  return res.json({
+    message: `Token confirmed for user ${user}`,
+    user,
+    light,
+    product,
+    ttl,
+  })
 })
 
 // GET /refresh


### PR DESCRIPTION
Augmented `/confirm` endpoint to include more information about the JWT (most importantly the TTL). The new information included in the response facilitates features introduced in EQWorks/common-login#18

existing response payload: 
```
message: <string>,
user: <string>
light: <bool>
```

new response payload: 
```
message: <string>,
user: <string>
confirmed: <bool>
light: <bool>
product: <string>
ttl: {
  millis: <number>
  friendly: <string>
}
```
`ttl.millis` = milliseconds until JWT expiration
`ttl.friendly` = human-readable version of `ttl.millis`