### PR TITLE
[G2M] API - Force light check on refresh + Refactor

### DIFF
--- a/api/middleware.js
+++ b/api/middleware.js
@@ -1,72 +1,91 @@
 const { verifyJWT, confirmUser } = require('../modules/auth')
 const { PRODUCT_ATOM } = require('../constants')
-const { sentry, AuthorizationError, APIError } = require('../modules/errors')
+const { AuthorizationError, APIError, InternalServerError, LOG_LEVEL_ERROR } = require('../modules/errors')
 const moment = require('moment-timezone')
 
 
 // JWT confirmation middleware
-const confirmed = ({ allowLight = false } = {}) => (req, res, next) => {
-  const { light, reset_uuid, product: targetProduct = PRODUCT_ATOM } = req.query
-  const fields = ['email', 'api_access', 'jwt_uuid']
-  const token = req.get('eq-api-jwt')
-
-  let user
-  // preliminary jwt verify
+// forceLight takes precedence over allowLight when the former resolves to true
+/**
+ * Factory function for access verification middleware
+ * Light check only confirms integrity of JWT while full check confirms that
+ * JWT access payload aligns with the user's CURRENT permissions
+ * @param {Object} options 
+ * @param {boolean|(access: object) => boolean} [options.forceLight=false] Boolean flag or callback function to indicate whether
+ * //to force a light check or not
+ * @param {boolean|(access: object) => boolean} [options.allowLight=false] Boolean flag or callback function to indicate whether
+ * // to allow a  check or not. When resolving to true, the caller may request a light check by supplying req.light === '1'|'true'
+ * @returns {function} Middleware function
+ */
+const confirmed = ({ forceLight = false, allowLight = false } = {}) => async (req, res, next) => {
   try {
-    user = verifyJWT(token)
-  } catch (err) {
-    // log raw error from JWT to Sentry
-    sentry().logError(err)
-    console.error(`[ERROR] ${err.message}`, err.stack || err)
-    return next(new AuthorizationError(`Invalid JWT: ${token}`))
-  }
+    const { light, reset_uuid, product: targetProduct = PRODUCT_ATOM } = req.query
+    const fields = ['email', 'api_access', 'jwt_uuid']
+    const token = req.get('eq-api-jwt')
 
-  // set product to atom if missing from jwt or falsy for backward compatibility
-  user.product = user.product || PRODUCT_ATOM
+    let user
+    // preliminary jwt verify
+    try {
+      user = verifyJWT(token)
+    } catch (err) {
+      // wrap error and up log level so it is logged to Sentry
+      throw new AuthorizationError.fromError(err, { message: `Invalid JWT: ${token}`, logLevel: LOG_LEVEL_ERROR })
+    }
 
-  // payload fields existence check
-  if (!fields.every(k => k in user)) {
-    return next(new AuthorizationError('JWT missing required fields in payload'))
-  }
+    // set product to atom if missing from jwt or falsy for backward compatibility
+    user.product = user.product || PRODUCT_ATOM
 
-  // product check
-  if (targetProduct !== 'all' && user.product.toLowerCase() !== targetProduct.toLowerCase()) {
-    return next(new AuthorizationError('JWT not valid for this resource'))
-  }
+    // payload fields existence check
+    if (!fields.every(k => k in user)) {
+      throw new AuthorizationError('JWT missing required fields in payload')
+    }
 
-  // DB integrity check
-  if (allowLight && ['1', 'true'].includes(light)) {
-    req.userInfo = { ...user, light: true }
-    return next()
-  }
+    // product check
+    const safeTargetProduct = targetProduct.toLowerCase()
+    if (safeTargetProduct !== 'all' && user.product !== safeTargetProduct) {
+      throw new AuthorizationError('JWT not valid for this resource')
+    }
 
-  // determine JWT TTL
-  const ttl = 'exp' in user
-    ? 1000 * user.exp - Date.now()
-    : -1
-  req.ttl = {
-    millis: ttl,
-    friendly: moment.duration(ttl).humanize()
-  }
+    // determine JWT TTL
+    const ttl = 'exp' in user ? 1000 * user.exp - Date.now() : -1
+    req.ttl = {
+      millis: ttl,
+      friendly: moment.duration(ttl).humanize()
+    }
 
-  confirmUser({
-    ...user,
-    reset_uuid: ['1', 'true'].includes(reset_uuid),
-    // check accesses relative to product embedded in jwt when query param 'product' === 'all'
-    product: (targetProduct === 'all' ? user.product : targetProduct),
-  })
-    .then(userInfo => {
-      req.userInfo = { ...userInfo, light: false }
+    // DB integrity check
+    if (
+      typeof forceLight === 'function' ? forceLight(user) : forceLight
+      || (
+        typeof allowLight === 'function' ? allowLight(user) : allowLight
+        && ['1', 'true'].includes((light || '').toLowerCase())
+      )
+    ) {
+      req.userInfo = { ...user, light: true }
       return next()
+    }
+
+    const userInfo = await confirmUser({
+      ...user,
+      reset_uuid: ['1', 'true'].includes((reset_uuid || '').toLowerCase()),
+      // check accesses relative to product embedded in jwt when query param 'product' === 'all'
+      product: safeTargetProduct === 'all' ? user.product : safeTargetProduct,
     })
-    .catch(next)
+    req.userInfo = { ...userInfo, light: false }
+    return next()
+  } catch (err) {
+    if (err instanceof APIError) {
+      return next(err)
+    }
+    next(InternalServerError.fromError(err, 'Failed to validate the existing token'))
+  }
 }
 
 // query parameter check middleware
 const hasQueryParams = (...params) => (req, res, next) => {
   for (const param of params) {
     if (!req.query[param]) {
-      return next(new APIError({ message: `Missing '${param}' in query string parameters`, statusCode: 400, logLevel: 'WARNING' }))
+      return next(new APIError({ message: `Missing '${param}' in query string parameters`, statusCode: 400 }))
     }
   }
   return next()

--- a/authorizer/index.js
+++ b/authorizer/index.js
@@ -1,5 +1,6 @@
 const { verifyJWT, confirmUser } = require('../modules/auth')
 const { PREFIX_MOBILE_SDK, PREFIX_PUBLIC, PRODUCT_ATOM } = require('../constants')
+const { APIError } = require('../modules/errors')
 
 
 // Helper function to generate an IAM policy
@@ -28,7 +29,7 @@ const getUserAccess = async (token) => {
 
   // payload fields existence check
   if (['email', 'api_access', 'jwt_uuid'].some(field => !(field in access))) {
-    throw Error('JWT missing required fields in payload')
+    throw new APIError({ message: 'JWT missing required fields in payload', statusCode: 400 })
   }
 
   // light check for mobile SDK
@@ -61,7 +62,7 @@ const isPublicToken = (token) => token.indexOf('public') !== -1
 const getAPIRootResource = (resource) => {
   const matches = resource.match(/^arn:aws:execute-api:[^/]+\/[^/]+\//)
   if (!matches || matches.length !== 1) {
-    throw Error('Not an API resource')
+    throw new APIError({ message: 'Not an API resource', statusCode: 400 })
   }
   return `${matches[0]}*`
 }


### PR DESCRIPTION
- Ability to force light check in confirm middleware
  - Implement forced light check for `/refresh` when `prefix === 'mobilesdk'`
  - Remove ability for holders of `mobilesdk` tokens to trade same across products
- Move input validation to middleware (entry points)
- Improve error handling at middleware level:
  - Remove root error messages from return payload
  - Add catch-all try/catch block to generate more meaningful error messages (vs. app catch-all)
  - As part of this effort, move to async/await logic