### PR TITLE
[G2M] access - send access object in /verify and /confirm

### DIFF
--- a/modules/auth.js
+++ b/modules/auth.js
@@ -159,7 +159,7 @@ const verifyOTP = async ({ email, otp, reset_uuid = false, product = PRODUCT_ATO
     product,
   })
 
-  return signJWT({ email, api_access, jwt_uuid, prefix, product }, { timeout })
+  return { token: signJWT({ email, api_access, jwt_uuid, prefix, product }, { timeout }), api_access }
 }
 
 const verifyJWT = token => jwt.verify(token, JWT_SECRET)


### PR DESCRIPTION
adds an `access` object to the `/verify`, `/confirm` and `/refresh` payloads: 
![image](https://user-images.githubusercontent.com/53827672/144486809-ec6b206e-a6bc-4dff-9b21-3959806cba83.png)

[context](https://eqworks.slack.com/archives/G1FDULP1R/p1638370620192800), specifically [here](https://eqworks.slack.com/archives/G1FDULP1R/p1638469360244500?thread_ts=1638370620.192800&cid=G1FDULP1R)