### PR TITLE
[G2M] devops - don't usage npx for @eqworks/notify jobs

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -54,9 +54,11 @@ jobs:
           # keywarden API version, passthrough
           KEYWARDEN_VER: ${{ github.sha }}
 
+      - run: npm install -g @eqworks/notify
+
       - name: Notify on deployment status
         if: ${{ always() }}
-        run: npx @eqworks/notify deployment ${GITHUB_REPOSITORY} --commit=${GITHUB_SHA} --stage=${STAGE} --status=${JOB_STATUS}
+        run: notify deployment ${GITHUB_REPOSITORY} --commit=${GITHUB_SHA} --stage=${STAGE} --status=${JOB_STATUS}
         env:
           SLACK_HOOK: ${{ secrets.CD_SLACK_HOOK }}
           JOB_STATUS: ${{ job.status }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -52,9 +52,11 @@ jobs:
           # keywarden API version, passthrough
           KEYWARDEN_VER: ${{ github.sha }}
 
+      - run: npm install -g @eqworks/notify
+
       - name: Notify on deployment status
         if: ${{ always() }}
-        run: npx @eqworks/notify deployment ${GITHUB_REPOSITORY} --commit=${GITHUB_SHA} --stage=${STAGE} --status=${JOB_STATUS}
+        run: notify deployment ${GITHUB_REPOSITORY} --commit=${GITHUB_SHA} --stage=${STAGE} --status=${JOB_STATUS}
         env:
           SLACK_HOOK: ${{ secrets.CD_SLACK_HOOK }}
           JOB_STATUS: ${{ job.status }}
@@ -67,7 +69,7 @@ jobs:
 
       - name: Notify on release notes update
         if: ${{ success() }}
-        run: npx @eqworks/notify send "Release notes updated for ${GITHUB_REPOSITORY} ${GITHUB_REF##*/}" --link "https://github.com/EQWorks/${GITHUB_REPOSITORY}/tag/${GITHUB_REF##*/}" --status ${JOB_STATUS}
+        run: notify send "Release notes updated for ${GITHUB_REPOSITORY} ${GITHUB_REF##*/}" --link "https://github.com/EQWorks/${GITHUB_REPOSITORY}/tag/${GITHUB_REF##*/}" --status ${JOB_STATUS}
         env:
           SLACK_HOOK: ${{ secrets.CD_SLACK_HOOK }}
           JOB_STATUS: ${{ job.status }}


### PR DESCRIPTION
using `npm i -g` instead of `npx` for `@eqworks/notify`. Context [here](https://eqworks.slack.com/archives/CB7557258/p1639581753001800).

Without this change, workflow runs with `notify` jobs fail. If this issue begins to occur with [other projects that use `npx @eqworks/release` in their workflows](https://github.com/search?p=2&q=org%3AEQWorks+%22npx+%40eqworks%2Fnotify%22&type=Code) we may have to look deeper into the root cause of this issue.

- [successful workflow run on this branch](https://github.com/EQWorks/keywarden/runs/4563934469?check_suite_focus=true)
- [resulting deployment notification](https://eqworks.slack.com/archives/C1JHL8L3U/p1639765352032700)