### PR TITLE
[G2M] access - include prefix inside access in various routes

### DIFF
--- a/modules/auth.js
+++ b/modules/auth.js
@@ -159,7 +159,7 @@ const verifyOTP = async ({ email, otp, reset_uuid = false, product = PRODUCT_ATO
     product,
   })
 
-  return { token: signJWT({ email, api_access, jwt_uuid, prefix, product }, { timeout }), api_access }
+  return { token: signJWT({ email, api_access, jwt_uuid, prefix, product }, { timeout }), api_access, prefix }
 }
 
 const verifyJWT = token => jwt.verify(token, JWT_SECRET)


### PR DESCRIPTION
[ref](https://eqworks.slack.com/archives/C011LML4ZTN/p1643209250012800)

Looks like the method of retrieving `access` did not include `prefix`, which is essential for determining access to various features inside the product