### PR TITLE
[G2M] access - fix double var declaration

### DIFF
--- a/api/root.js
+++ b/api/root.js
@@ -125,7 +125,7 @@ router.get(
       }
     
       const token = signJWT(userInfo, { timeout })
-      const { api_access, prefix } = userInfo
+      const { api_access } = userInfo
 
       return res.json({
         message: `Token refreshed for user ${email}, please store and use the token responsibly`,


### PR DESCRIPTION
`prefix` was declared twice