### PR TITLE
[G2M] jwt - give "N/A" expiry message for permanent jwt

### DIFF
--- a/api/middleware.js
+++ b/api/middleware.js
@@ -25,10 +25,17 @@ const confirmed = ({ forceLight = false, allowLight = false } = {}) => async (re
     let user = await getUserAccess({ token, light, reset_uuid, targetProduct, forceLight, allowLight })
 
     // determine JWT TTL
-    const ttl = 'exp' in user ? 1000 * user.exp - Date.now() : -1
-    req.ttl = {
-      millis: ttl,
-      friendly: moment.duration(ttl).humanize(),
+    if ('exp' in user) {
+      const millis = 1000 * user.exp - Date.now()
+      req.ttl = {
+        millis,
+        friendly: moment.duration(millis).humanize(),
+      }
+    } else {
+      req.ttl = {
+        millis: -1,
+        friendly: 'N/A',
+      }
     }
     req.userInfo = user
     return next()


### PR DESCRIPTION
fixes issue where a jwt expiration of `-1` milliseconds would have a `friendly` representation of `'a few seconds'`. This is misleading because `-1` would actually mean the token will never expire. Opted for `'N/A'` instead.