### PR TITLE
[G2M] user/soft-delete - add soft-delete option to 'user/delete' endpoint

### DIFF
--- a/api/users.js
+++ b/api/users.js
@@ -30,8 +30,8 @@ router.get('/', hasQueryParams('user'), confirmed(), (req, res, next) => {
 // GET /users/list
 router.get('/list', confirmed(), (req, res, next) => {
   const { userInfo } = req
-  const { product, active } = req.query
-  getUsers({ ...userInfo, product, active })
+  const { product, active, deleted } = req.query
+  getUsers({ ...userInfo, product, active, deleted })
     .then(({ users }) => res.json(users))
     .catch(next)
 })


### PR DESCRIPTION
### Changes

- **`users/delete`**
  - change from hard delete to soft delete
  - soft delete user by set user to ↓
```
  {
    prefix: 'customers',
    jwt_uuid: null,
    client: null,
    atom: { read: 10, write: 0 },
    active: 0,
    access: null,
  }
```

- **`users/list`**
(won't return soft-deleted user)
  - add `active` param 

    - active equal 'all' - return all users 
    - active equal 1 or true - only return active users
    - active equal 0 or false - only return inactive users
    
  -  add `deleted` param 
     - deleted equal 1 or true will include deleted users in the user list

- https://github.com/EQWorks/common-user/pull/6