### PR TITLE
[G2M] user/verify - include the user info in the response

### DIFF
--- a/modules/auth.js
+++ b/modules/auth.js
@@ -45,7 +45,7 @@ const isPrivilegedUser = (email, prefix, api_access) => {
 
 const getUserInfo = async ({ email, product = PRODUCT_ATOM }) => {
   // returns user info
-  const selects = ['prefix', 'jwt_uuid', 'client', 'access', PRODUCT_ATOM, PRODUCT_LOCUS]
+  const selects = ['prefix', 'jwt_uuid', 'client', 'access', 'info', PRODUCT_ATOM, PRODUCT_LOCUS]
   const conditions = ["active = B'1'"]
   const user = await selectUser({ email, selects, conditions })
 
@@ -66,6 +66,7 @@ const getUserInfo = async ({ email, product = PRODUCT_ATOM }) => {
     email,
     product, // v0; deprecated in v1+
     api_access: {
+      info: user.info,
       ...user.client, // v0, v1; to be deprecated in v2+
       ...productAccess, // v0; to be deprecated in v1+
       version: 0, // denotes legacy pre-`access` format


### PR DESCRIPTION
### Change

- GET /verify - include the user info in the response
(So that snoke-dashboard can simply get the dealer's name from local storage, and show the name in the "Welcome back" intro line
![user-info](https://user-images.githubusercontent.com/76548841/197609349-206952ef-0913-4667-982f-91cafdd657b2.jpg)
)

related to https://github.com/EQWorks/common-user/pull/7