### PR TITLE
[G2M] auth - adds support for account expiry

### DIFF
--- a/api/root.js
+++ b/api/root.js
@@ -93,13 +93,14 @@ router.get('/verify', hasQueryParams('user', 'otp'), async (req, res, next) => {
 
 // GET /confirm
 router.get('/confirm', confirmed({ allowLight: true }), (req, res) => {
-  const { ttl, userInfo: { email: user, light, api_access, prefix, product } } = req
+  const { ttl, userInfo: { email: user, light, api_access, prefix, product, access_expired_at } } = req
   return res.json({
     message: `Token confirmed for user ${user}`,
     user,
     light,
     product,
     ttl,
+    access_expired_at,
     access: {
       ...api_access,
       prefix,

--- a/modules/manage.js
+++ b/modules/manage.js
@@ -58,7 +58,7 @@ const _prepareConditions = ({ prefix, api_access, product = PRODUCT_ATOM, active
   return conditions
 }
 
-const BASE_SELECTS = ['email', 'prefix', 'client', 'info', 'access', 'active']
+const BASE_SELECTS = ['email', 'prefix', 'client', 'info', 'access', 'active', 'access_expired_at']
 // list users that the given user (email) has access to
 const getUsers = ({ prefix, api_access, product = PRODUCT_ATOM, active, deleted }) => {
   if (api_access.version) {
@@ -135,6 +135,7 @@ const removeUser = ({ userInfo, prefix, api_access }) => {
     atom: { read: 10, write: 0 },
     active: 0,
     access: null,
+    access_expired_at: null,
   })
 }
 

--- a/sql/equsers.sql
+++ b/sql/equsers.sql
@@ -10,6 +10,8 @@ CREATE TABLE IF NOT EXISTS public.equsers (
     info JSONB DEFAULT '{}'::JSONB,
     otp JSONB DEFAULT '{}'::JSONB,
     active BIT(1) DEFAULT B'1'::BIT(1),
+    access JSONB,
+    access_expired_at TIMESTAMPTZ,
     PRIMARY KEY(email)
 );
 


### PR DESCRIPTION
Adds support for account expiration through a new `access_expired_at` field. If set, the system calculates the JWT token’s expiry based on this value. Once the expiration time has passed, the user is automatically deactivated and blocked.

### Changes
- Introduced `access_expired_at` column (TIMESTAMPTZ) in the user schema
- Updated `getUserInfo` to deactivate user if access has expired
- JWT TTL is now dynamically computed based on `access_expired_at`
- If the access has expired, the user is deactivated and an AuthorizationError is thrown with a clear user-facing message.